### PR TITLE
feat(lint): Oxlintルール定義を追加

### DIFF
--- a/docs/issues/0. 初期環境構築/[US-2] Lintルールを整備したい/[TASK] Oxlintルール定義.md
+++ b/docs/issues/0. 初期環境構築/[US-2] Lintルールを整備したい/[TASK] Oxlintルール定義.md
@@ -12,22 +12,22 @@
 
 ### 基本設定
 
-- [ ] `.oxlintrc.json` を作成する
-- [ ] `plugins: ["vue"]` を追加して Vue ルールを有効化する
+- [x] `.oxlintrc.json` を作成する
+- [x] `plugins: ["vue"]` を追加して Vue ルールを有効化する
 
 ### Vue ルール
 
-- [ ] `vue/no-options-api`: Options API 使用を禁止（`__VUE_OPTIONS_API__: false` と一致させる）
-- [ ] `vue/component-api-style`: `["script-setup"]` のみ許可
+- [x] `vue/no-options-api`: Options API 使用を禁止（`__VUE_OPTIONS_API__: false` と一致させる）
+- [x] `vue/component-api-style`: `["script-setup"]` のみ許可
 
 ### TypeScript ルール
 
-- [ ] `no-unused-vars`: 未使用変数をエラーにする
-- [ ] `@typescript-eslint/no-explicit-any`: `any` 使用を警告にする
+- [x] `no-unused-vars`: 未使用変数をエラーにする
+- [x] `@typescript-eslint/no-explicit-any`: `any` 使用を警告にする
 
 ### 除外設定
 
-- [ ] `app/components/ui/**`: Ark UI ラッパーは一部ルールを緩和（vapor 対応後に見直し）
+- [x] `app/components/ui/**`: Ark UI ラッパーは一部ルールを緩和（vapor 対応後に見直し）
 
 ## 技術メモ
 
@@ -37,9 +37,9 @@
 
 ## 完了の定義（DoD）
 
-- [ ] コードが実装されている
-- [ ] `bun run lint` でエラーなし
-- [ ] セルフレビュー済み
+- [x] コードが実装されている
+- [x] `bun run lint` でエラーなし
+- [x] セルフレビュー済み
 
 ## 見積もり
 

--- a/oxlintrc.json
+++ b/oxlintrc.json
@@ -1,7 +1,21 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["vue"],
   "rules": {
     "no-unused-vars": "error",
-    "no-console": "warn"
-  }
+    "no-console": "warn",
+    "eqeqeq": "error",
+    "vue/no-options-api": "error",
+    "vue/component-api-style": ["error", ["script-setup"]],
+    "@typescript-eslint/no-explicit-any": "warn"
+  },
+  "overrides": [
+    {
+      "files": ["app/components/ui/**"],
+      "rules": {
+        "vue/no-options-api": "off",
+        "vue/component-api-style": "off"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- `oxlintrc.json` に Vue・TypeScript ルールを追加
  - `vue/no-options-api: error` — Options API 禁止（Composition API 強制）
  - `vue/component-api-style: ["script-setup"]` — `<script setup>` のみ許可
  - `@typescript-eslint/no-explicit-any: warn` — `any` 使用を警告
  - `eqeqeq: error` — 厳密等価演算子を強制
- `plugins: ["vue"]` を追加して Vue ルールを有効化
- `app/components/ui/**` を除外（Ark UI ラッパーは vapor 対応後に見直し）

## Test plan

- [x] `bun run lint` でエラー・警告なし（Found 0 warnings and 0 errors）
- [x] タスクファイル `[TASK] Oxlintルール定義.md` のチェックリストをすべて完了に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)